### PR TITLE
GH-6 - Fix: Handle Post variable trust_path

### DIFF
--- a/inc/save.php
+++ b/inc/save.php
@@ -52,7 +52,8 @@ function save() {
 		),
 	);
 
-	update_option( 'trust_custom_path', sanitize_text_field( $_post['trust_path'] ) );
+	$trust_path = isset( $_post['trust_path'] ) ? sanitize_text_field( $_post['trust_path'] ) : '0';
+	update_option( 'trust_custom_path', $trust_path );
 
 	if ( ! $doing_ajax || empty( $errors ) || 'y' === $ays ) {
 		$post_id = wp_insert_post( $postarr );


### PR DESCRIPTION
Implemented handling for the POST variable 'trust_path' to check if it is set. Previously, an error occurred when the .well-known field was unchecked, as it was not being passed in the form.
