### PR TITLE
GH-12: Add support for Trust.txt rules as of April 2024

### DIFF
--- a/inc/admin.php
+++ b/inc/admin.php
@@ -392,17 +392,18 @@ function display_formatted_error( $error ) {
  */
 function get_error_messages() {
 	$messages = array(
-		'invalid_variable'            => __( 'The first word in this line is not one of the recognized variables. Please see JournalList.net for allowed variables.' ),
-		'invalid_record'              => __( 'This line does not conform with the trust.txt recommendations. Please read about what is recommended on JournalList.net.' ),
-		'invalid_social'              => __( '%s does not appear to be a valid social media domain' ),
+		'invalid_variable'                  => __( 'The first word in this line is not one of the recognized variables. Please see JournalList.net for allowed variables.' ),
+		'invalid_record'                    => __( 'This line does not conform with the trust.txt recommendations. Please read about what is recommended on JournalList.net.' ),
+		'invalid_social'                    => __( '%s does not appear to be a valid social media domain' ),
 		/* translators: %s: Domain */
-		'invalid_domain'              => __( '%s does not appear to be a valid domain' ),
+		'invalid_domain'                    => __( '%s does not appear to be a valid domain' ),
 		/* translators: %s: Domain */
-		'invalid_disclosure'          => __( '%s does not appear to be a valid URL' ),
-		'invalid_datatrainingallowed' => __( 'Invalid input. Please enter "yes" or "no" (case-sensitive)' ),
+		'invalid_disclosure'                => __( '%s does not appear to be a valid URL' ),
+		'invalid_datatrainingallowed'       => __( 'Invalid input. Please enter "yes" or "no" (case-sensitive)' ),
+		'invalid_datatrainingallowed_count' => __( 'Only one datatrainingallowed record is allowed' ),
 		/* translators: %s: contact information */
-		'invalid_contact'             => __( '%s does not appear to be a valid contact information' ),
-		'invalid_blank'               => __( 'This field can not be blank. Either remove it or add valid value' ),
+		'invalid_contact'                   => __( '%s does not appear to be a valid contact information' ),
+		'invalid_blank'                     => __( 'This field can not be blank. Either remove it or add valid value' ),
 	);
 
 	return $messages;

--- a/inc/admin.php
+++ b/inc/admin.php
@@ -392,16 +392,17 @@ function display_formatted_error( $error ) {
  */
 function get_error_messages() {
 	$messages = array(
-		'invalid_variable'     => __( 'The first word in this line is not one of the recognized variables. Please see JournalList.net for allowed variables.' ),
-		'invalid_record'       => __( 'This line does not conform with the trust.txt recommendations. Please read about what is recommended on JournalList.net.' ),
-		'invalid_social'       => __( '%s does not appear to be a valid social media domain' ),
+		'invalid_variable'            => __( 'The first word in this line is not one of the recognized variables. Please see JournalList.net for allowed variables.' ),
+		'invalid_record'              => __( 'This line does not conform with the trust.txt recommendations. Please read about what is recommended on JournalList.net.' ),
+		'invalid_social'              => __( '%s does not appear to be a valid social media domain' ),
 		/* translators: %s: Domain */
-		'invalid_domain'       => __( '%s does not appear to be a valid domain' ),
+		'invalid_domain'              => __( '%s does not appear to be a valid domain' ),
 		/* translators: %s: Domain */
-		'invalid_disclosure'   => __( '%s does not appear to be a valid URL' ),
+		'invalid_disclosure'          => __( '%s does not appear to be a valid URL' ),
+		'invalid_datatrainingallowed' => __( 'Invalid input. Please enter "yes" or "no" (case-sensitive)' ),
 		/* translators: %s: contact information */
-		'invalid_contact'      => __( '%s does not appear to be a valid contact information' ),
-		'invalid_blank'        => __( 'This field can not be blank. Either remove it or add valid value' ),
+		'invalid_contact'             => __( '%s does not appear to be a valid contact information' ),
+		'invalid_blank'               => __( 'This field can not be blank. Either remove it or add valid value' ),
 	);
 
 	return $messages;

--- a/inc/save.php
+++ b/inc/save.php
@@ -101,12 +101,12 @@ function validate_line( $line, $line_number ) {
 		$sanitized = wp_strip_all_tags( $line );
 	} elseif ( 1 < strpos( $line, '=' ) ) { // This is a variable declaration.
 		// The spec currently supports member, belongto, control, controlledby, social, disclosure and contact
-		if ( ! preg_match( '/^(member|belongto|control|controlledby|social|disclosure|contact)=/i', $line ) ) {
+		if ( ! preg_match( '/^(member|belongto|control|controlledby|social|disclosure|contact|datatrainingallowed)=/i', $line ) ) {
 			$errors[] = array(
 				'line' => $line_number,
 				'type' => 'invalid_variable',
 			);
-		} elseif ( preg_match( '/^(member|belongto|control|controlledby|disclosure|social|contact)=/i', $line ) ) {
+		} elseif ( preg_match( '/^(member|belongto|control|controlledby|disclosure|social|contact|datatrainingallowed)=/i', $line ) ) {
 			// If we have a valid spec from the above list, check if the domain format is correct
 			// This elseif condition is unnecessary but in future it will be needed
 	
@@ -128,6 +128,10 @@ function validate_line( $line, $line_number ) {
 				// Use special contact regex for validation
 				$validation_regex = $disclosure_regex;
 				$error_type       = 'invalid_disclosure';
+			} elseif ( 0 === stripos( $line, 'datatrainingallowed=' ) ) {
+				// Use special contact regex for validation
+				$validation_regex = '/^(yes|no)$/i';
+				$error_type       = 'invalid_datatrainingallowed';
 			}
 
 			if ( '' === $spec[0] ) {

--- a/inc/save.php
+++ b/inc/save.php
@@ -102,12 +102,12 @@ function validate_line( $line, $line_number ) {
 		$sanitized = wp_strip_all_tags( $line );
 	} elseif ( 1 < strpos( $line, '=' ) ) { // This is a variable declaration.
 		// The spec currently supports member, belongto, control, controlledby, social, disclosure and contact
-		if ( ! preg_match( '/^(member|belongto|control|controlledby|social|disclosure|contact|datatrainingallowed)=/i', $line ) ) {
+		if ( ! preg_match( '/^(member|belongto|control|controlledby|social|disclosure|contact|vendor|customer|datatrainingallowed)=/i', $line ) ) {
 			$errors[] = array(
 				'line' => $line_number,
 				'type' => 'invalid_variable',
 			);
-		} elseif ( preg_match( '/^(member|belongto|control|controlledby|disclosure|social|contact|datatrainingallowed)=/i', $line ) ) {
+		} elseif ( preg_match( '/^(member|belongto|control|controlledby|disclosure|social|contact|vendor|customer|datatrainingallowed)=/i', $line ) ) {
 			// If we have a valid spec from the above list, check if the domain format is correct
 			// This elseif condition is unnecessary but in future it will be needed
 

--- a/inc/save.php
+++ b/inc/save.php
@@ -91,7 +91,6 @@ add_action( 'wp_ajax_trusttxt-save', __NAMESPACE__ . '\save' );
  * }
  */
 function validate_line( $line, $line_number ) {
-
 	$domain_regex       = '/^(https?):\/\/((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}(\/)?([a-z0-9-.\/_]*)$/i';
 	$disclosure_regex   = '/^(https?):\/\/((?=[a-z0-9-]{1,63}\.)(xn--)?[a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,63}(\/)?([a-z0-9-.\/_]*.txt)$/i';
 	$errors             = array();

--- a/trust-txt.php
+++ b/trust-txt.php
@@ -61,6 +61,7 @@ function rtcamp_display_trust_txt() {
 			 *
 			 * @param type  $trusttxt The existing trust.txt content.
 			 */
+			ob_clean();
 			echo esc_html( apply_filters( 'trust_txt_content', $trusttxt ) );
 			die();
 		}


### PR DESCRIPTION
- Added Support for `datatrainingallowed`, can accept `yes` and `no` only, and can be added only `once` in `trust.txt`.
- Added support for `vendor`.
- Added support for `customer`.